### PR TITLE
Fix navig. menu hover display

### DIFF
--- a/assets/css/redhat.css
+++ b/assets/css/redhat.css
@@ -2411,6 +2411,9 @@ table.tableblock.grid-all td.tableblock {
     color: #465158
 }
 
+#toc.toc2 ul.sectlevel1 a {
+    border-right: 3px solid transparent;
+}
 #toc.toc2 ul.sectlevel1 a:hover,
 #toc.toc2 ul.sectlevel1 a:focus {
     color: #000;


### PR DESCRIPTION
A quick fix to avoid line wrapping in navigation. This adds a CSS definition to have a right-hand border on navig. menu items at all times (i.e. not only when the cursor is hovering above the item). Thus, lines that are too long and would wrap on hover are always wrapped, which prevents the wrapping-unwrapping on cursor movement.

See the GIF , which illustrates  what the new CSS rule fixes.
![Peek 2023-06-10 12-56](https://github.com/redhat-documentation/redhat-docs-template/assets/6623103/d0184576-aac3-41a0-bb3f-f85aef7ad42b)

----------

Btw, thank you for putting the template together and publishing it.